### PR TITLE
Adapt to removal of apostrophe as package separator

### DIFF
--- a/t/defer.t
+++ b/t/defer.t
@@ -266,7 +266,7 @@ Automaticaly fudge the factors.
 Step size.
 
 =for Euclid:
-   step.default: $STEP1 + $STEPS->{extra} + $$STEPS{extra} + ${$STEPS}{extra} + $main'STEP2
+   step.default: $STEP1 + $STEPS->{extra} + $$STEPS{extra} + ${$STEPS}{extra} + $main::STEP2
 
 =item --version
 


### PR DESCRIPTION
As of perl-5.41.3 (Aug 2024).